### PR TITLE
Fix Overwriting of Strings in DocumentWriter Constructor

### DIFF
--- a/src/mupdf.ts
+++ b/src/mupdf.ts
@@ -1543,7 +1543,7 @@ export class DocumentWriter extends Userdata {
 			libmupdf._wasm_new_document_writer_with_buffer(
 				BUFFER(buffer),
 				STRING(format),
-				STRING(options)
+				STRING2(options)
 			)
 		)
 	}


### PR DESCRIPTION
## Problem
In the `DocumentWriter` class constructor, both the `format` and `options` strings were being allocated using the `STRING` function, leading to the second call overwriting the first. This was due to both calls using the same index for string allocation in the WASM environment.

## Solution
This PR fixes the issue by changing the allocation of the `options` string to use the `STRING2` function instead. This ensures that `format` and `options` are allocated at separate indices, preventing data overwrite and ensuring correct behavior of the `DocumentWriter` constructor.

## Changes Made
- Modified the `DocumentWriter` constructor to use `STRING` for the `format` string and `STRING2` for the `options` string.