### PR TITLE
wait for worker to initalize before calling open_document_from_buffer

### DIFF
--- a/examples/simple-viewer/viewer.js
+++ b/examples/simple-viewer/viewer.js
@@ -707,6 +707,18 @@ function close_document() {
 }
 
 async function open_document_from_buffer(buffer, magic, title) {
+	if (!worker.isInitialized) {
+	  await new Promise((resolve) => {
+	    worker.addEventListener("message", function listener(event) {
+	      if (event.data[0] === "INIT") {
+	        worker.removeEventListener("message", listener);
+	        worker.isInitialized = true;
+	        resolve();
+	      }
+	    });
+	  });
+	}
+
 	current_doc = await worker.openDocumentFromBuffer(buffer, magic)
 
 	document.title = await worker.documentTitle(current_doc) || title


### PR DESCRIPTION
I tried to use the example viewer with react through useeffect. I got the following error ``` TypeError: undefined is not an object (evaluating 'worker.methods.openDocumentFromBuffer') — ``` It was caused because the open_document_from_buffer function in viewer.js was called before the worker was initialized. My change waits for the worker to intialize before opening a file and after it's initalized it adds a property to the worker that it's initialized so it can open further documents