### PR TITLE
Fix import statements.

### DIFF
--- a/src/mupdf.ts
+++ b/src/mupdf.ts
@@ -22,7 +22,8 @@
 
 "use strict"
 
-import { libmupdf_wasm, Pointer } from "./mupdf-wasm.js"
+import { Pointer } from "./mupdf-wasm.js"
+import libmupdf_wasm from "./mupdf-wasm.js"
 
 const libmupdf = await libmupdf_wasm()
 


### PR DESCRIPTION
Import the Pointer branded type separately from the Emscripten generated
default import.
