### PR TITLE
Issue #78: Change search box event to oninput

### DIFF
--- a/examples/simple-viewer/viewer.js
+++ b/examples/simple-viewer/viewer.js
@@ -583,7 +583,7 @@ let search_input = document.getElementById("search-input")
 var current_search_needle = ""
 var current_search_page = 0
 
-search_input.onchange = function (event) {
+search_input.oninput = function (event) {
 	run_search(event.shiftKey ? -1 : 1, 0)
 }
 


### PR DESCRIPTION
#78 

With the onChange event, processing is called when the focus is removed from the search box after text entry (or when the return key is pressed). Therefore, if the Next button is pressed without pressing the Return key after entering text, the search by the button is executed as soon as the focus is removed, so the search for the next page is executed immediately after the search for the current page is executed, so the page seems to be skipped.

If the search box is executed with the oninput event, the process will occur each time text is entered, ensuring that the search is executed on the current page.

You would be able to use it without any discomfort when pressing the Next button.