### PR TITLE
Improve search functionality

### DIFF
--- a/examples/simple-viewer/index.html
+++ b/examples/simple-viewer/index.html
@@ -84,8 +84,8 @@ CA 94129, USA, for further information.
 			size="40"
 			placeholder="Search..."
 		>
-		<button onclick="run_search(-1, 1)">Prev</button>
-		<button onclick="run_search(1, 1)">Next</button>
+		<button id="search-prev" onclick="run_search(-1, 1)">Prev</button>
+		<button id="search-next" onclick="run_search(1, 1)">Next</button>
 		<div id="search-status" style="flex-grow:1"></div>
 		<button onclick="hide_search_panel()">X</button>
 	</footer>

--- a/examples/simple-viewer/index.html
+++ b/examples/simple-viewer/index.html
@@ -84,8 +84,8 @@ CA 94129, USA, for further information.
 			size="40"
 			placeholder="Search..."
 		>
-		<button id="search-prev" onclick="run_search(-1, 1)">Prev</button>
-		<button id="search-next" onclick="run_search(1, 1)">Next</button>
+		<button id="search-prev" onclick="run_search(-1, 1)">&#x3C;</button>
+		<button id="search-next" onclick="run_search(1, 1)">&#x3E;</button>
 		<div id="search-status" style="flex-grow:1"></div>
 		<button onclick="hide_search_panel()">X</button>
 	</footer>


### PR DESCRIPTION
* Addresses issues #78 & #98 
  Fix the issue where the search results on the current page would be skipped when clicking the "Next" search button for the first time. 
  Improve the search experience for the Chinese input method.

* Add an Enter key handler for the search input. 
  Enter: search "Next"
  Shift + Enter: search "Prev"

* Display page number based on 1