### PR TITLE
use graft map

### DIFF
--- a/src/mupdfjs.ts
+++ b/src/mupdfjs.ts
@@ -406,6 +406,7 @@ export class PDFDocument extends mupdf.PDFDocument {
 
         const sourcePageCount = sourcePDF.countPages();
         const targetPageCount = this.countPages();
+	const graftMap = this.newGraftMap()
 
         // Normalize page numbers
         fromPage = Math.max(0, Math.min(fromPage, sourcePageCount - 1));
@@ -427,13 +428,13 @@ export class PDFDocument extends mupdf.PDFDocument {
             // Copy page contents
             const contents = pageObj.get("Contents");
             if (contents) {
-                newPageObj.put("Contents", this.graftObject(contents));
+                newPageObj.put("Contents", graftMap.graftObject(contents));
             }
 
             // Copy page resources
             const resources = pageObj.get("Resources");
             if (resources) {
-                newPageObj.put("Resources", this.graftObject(resources));
+                newPageObj.put("Resources", graftMap.graftObject(resources));
             }
 
             // Insert the new page at the specified position
@@ -517,11 +518,12 @@ export class PDFDocument extends mupdf.PDFDocument {
             var n: number = 0;
             while (n < ranges.length) { 
                 let newDoc = new mupdf.PDFDocument() as PDFDocument;
+		let graftMap = newDoc.newGraftMap()
                 
                 if (ranges[n] != undefined) {
                     for (let o: number = 0; o < ranges[n]!.length; o++) {
                         // note: "o" is the "to" number for graftPage()
-                        newDoc.graftPage(o, document, ranges[n]![o]!);
+                        graftMap.graftPage(o, document, ranges[n]![o]!);
                     }
                     documents.push(newDoc);
                 }

--- a/src/mupdfjs.ts
+++ b/src/mupdfjs.ts
@@ -79,11 +79,9 @@ export class PDFDocument extends mupdf.PDFDocument {
     _doc: mupdf.PDFDocument | undefined
 
     // bespoke constructor to ensure we get the correct type of PDFDocument instance
-    constructor(doc:mupdf.PDFDocument, isMuPDFJSDoc:boolean) {
+    constructor(doc:mupdf.PDFDocument) {
         super(doc.pointer)
-        if (isMuPDFJSDoc) {
-            this._doc = doc;
-        }
+	this._doc = doc;
     }
 
     // creates a new blank document with one page and adds a font resource, default size is A4 @ 595x842
@@ -93,7 +91,7 @@ export class PDFDocument extends mupdf.PDFDocument {
         doc.insertPage(-1, pageObj)
 
         if (doc instanceof mupdf.PDFDocument) {
-            return new PDFDocument(doc, true);
+            return new PDFDocument(doc);
         }
         throw new Error("Not a PDF document");
     }
@@ -102,7 +100,7 @@ export class PDFDocument extends mupdf.PDFDocument {
         let doc = super.openDocument(from, magic);
 
         if (doc instanceof mupdf.PDFDocument) {
-            return new PDFDocument(doc, true);
+            return new PDFDocument(doc);
         }
         throw new Error("Not a PDF document");
     }
@@ -708,6 +706,8 @@ export class PDFDocument extends mupdf.PDFDocument {
 }
 
 export class PDFPage extends mupdf.PDFPage {
+    // this is required so the page reference doesn't get garbage collected
+    _page: mupdf.PDFPage | undefined
 
     // note page number is zero-indexed here
     constructor(doc: mupdf.PDFDocument, pno: number) {
@@ -716,6 +716,7 @@ export class PDFPage extends mupdf.PDFPage {
         }
         let page: mupdf.PDFPage = doc.loadPage(pno)
         super(doc, page.pointer)
+	this._page = page
     }
 
     insertText(value: string,


### PR DESCRIPTION
- fix reference counting error in mupdfjs.PDFPage
- Use graft map when copying multiple pages and objects between documents.
