### PR TITLE
feat: add method for extracting words from doc

### DIFF
--- a/src/mupdfjs.ts
+++ b/src/mupdfjs.ts
@@ -51,13 +51,6 @@ export class StrokeState extends mupdf.StrokeState { }
 export class StructuredText extends mupdf.StructuredText { }
 export class Text extends mupdf.Text { }
 
-export type PDFWord = {
-	rect: Rect,
-	text: string,
-	font: Font,
-	size: number,
-};
-
 export function installLoadFontFunction(f: (name: string, script: string) => Buffer | null) {
 	mupdf.installLoadFontFunction(f)
 }
@@ -79,6 +72,13 @@ export type CreatableAnnotationType =
 	"Caret" |
 	"Ink" |
 	"FileAttachment"
+
+export type PDFWord = {
+	rect: Rect,
+	text: string,
+	font: Font,
+	size: number,
+};
 
 export class PDFDocument extends mupdf.PDFDocument {
 


### PR DESCRIPTION
This adds the getWords method, which enables extracting words (text + position + font + size) from the document.

Fix #143