### PR TITLE
Simple viewer example: Hide selected text to avoid overstrike

### DIFF
--- a/examples/simple-viewer/style.css
+++ b/examples/simple-viewer/style.css
@@ -202,6 +202,7 @@ svg.text text {
 
 svg.text ::selection {
 	background: hsla(220, 100%, 50%, 0.2);
+	color: transparent;
 }
 
 div.link a:hover {


### PR DESCRIPTION
The text layer doesn't necessarily use the same font and kerning as the rendered text. Especially for embedded fonts text selections will have slightly different placement of the individual glyphs, resulting in an "overstrike" effect. Avoid this by explicitly making the selected text transparent.